### PR TITLE
Fix futures not running in parallel

### DIFF
--- a/case_manager/helper_functions.py
+++ b/case_manager/helper_functions.py
@@ -356,7 +356,7 @@ def notify_stakeholders(
                 log_db=LOG_DB,
                 level="ERROR",
                 message="Stakeholders not notified. No recipient found for notification",
-                context=f"{LOG_CONTEXT}, ({process_name})",
+                context=f"{LOG_CONTEXT} ({process_name})",
                 db_env=db_env,
             )
 


### PR DESCRIPTION
Change from "for form in forms_data: executor.submit()" to "for future in concurrent.futures.as_completed()" lets futures run in parallel. The previous method did not allow for sync runs, because of the "res = future.result()" check for uncaugt exceptions in the main process. 